### PR TITLE
Replace unlzw with ncompress

### DIFF
--- a/geodezyx/files_rw/read_gnss_prods.py
+++ b/geodezyx/files_rw/read_gnss_prods.py
@@ -283,10 +283,9 @@ def read_sp3(file_path_in,returns_pandas = True, name = '',
         F = gzip.open(file_path_in, "r+")
         Lines = [e.decode('utf-8') for e in F]
     elif file_path_in[-2:] in (".Z",):
-        import unlzw
+        import ncompress
         fh = open(file_path_in, 'rb')
-        Fcompressed = fh.read()
-        F = unlzw.unlzw(Fcompressed).decode("utf-8") 
+        F = ncompress.decompress(fh).decode("utf-8") 
         Lines = F.split('\n')
     else:
         F = open(file_path_in,'r')

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ PyPi project: https://pypi.org/project/geodezyx
                       'sympy',
                       'tabulate',
                       'vincenty',
-                      'unlzw']  # Optional
+                      'ncompress']  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"


### PR DESCRIPTION
Hi! This super minor PR replaces the `unlzw` dependency with [ncompress](https://github.com/valgur/ncompress). `unlzw` has not had a binary release since Python 3.6 and the current version [is leaking memory](https://github.com/ionelmc/python-unlzw/pull/3).