### PR TITLE
Ajout valeur par défaut pour country_code dans le parser (corrige erreur rinex2)

### DIFF
--- a/geodezyx/operational/gins_runner/singugins_run.py
+++ b/geodezyx/operational/gins_runner/singugins_run.py
@@ -239,6 +239,7 @@ def main():
         "-cty",
         "--country_code",
         type=str,
+        default = "XXX",
         help="A string (3 caracter ISO code) to help find the right site code in case of ambiguity",
     )
 


### PR DESCRIPTION
En lançant singugins_run sans spécifier le code pays, sa valeur devient None. 
Pour un calcul avec des Rinex 3 la variable n'est pas utilisée mais pour les Rinex 2 elle est utilisée à la ligne 558 du fichier gins_dirs_gen.py pour générer les fichiers directeurs ce qui fait planter le calcul puisqu'une chaîne de caractère est attendue et pas un NoneType.

A priori cette variable n'est pas dans la branche main du git, mais elle est dans prod_singugins_01a qui est utilisée pour l'image docker singugins.

En soi, l'erreur n'existe pas si on spécifie un code pays à chaque fois, sinon en rajoutant une valeur par défaut ça évite de le faire.

<img width="1057" height="494" alt="image" src="https://github.com/user-attachments/assets/bf4c61f5-7063-4a7b-a789-3b8d135449e8" />
<img width="1056" height="531" alt="image(1)" src="https://github.com/user-attachments/assets/04fd3fcb-896d-45ec-8850-48ce74e873f4" />
<img width="1488" height="311" alt="image" src="https://github.com/user-attachments/assets/6f465df1-507c-4fc5-be05-e856ab61b06b" />

